### PR TITLE
recovery: play recovery.mp3 before playing shutdown effect

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,4 +19,3 @@ Enter the recovery mode.
 ### yoda-app://system/idle
 
 Enter the idle state that'd abandon all visibilities, i.e. stop all playing music or other visual tasks.
-

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     ]
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "pretest": "yoda-cli am force-stop system && yoda-cli pm install .",
+    "test": "yoda-cli am instrument system 'test/*.test.js' && yoda-cli am logread system"
   },
   "keywords": [
     "yodaos",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,5 +1,6 @@
 var mm = require('@yodaos/mm')
 var mock = require('@yodaos/mm/mock')
+var system = require('@yoda/system')
 var AudioFocus = require('@yodaos/application').AudioFocus
 
 mock.proxyMethod(require('@yoda/manifest'), 'get', {
@@ -35,3 +36,17 @@ test('should speak text', t => {
 
   t.suite.openUrl('yoda-app://system/shutdown')
 })
+
+test('should enter recovery mode', t => {
+  t.plan(2)
+
+  mock.mockReturns(system, 'setRecoveryMode', () => {
+    t.assert(true)
+  })
+  mock.mockReturns(system, 'reboot', reason => {
+    t.strictEqual(reason, 'recovery')
+    t.end()
+  })
+  t.suite.openUrl('yoda-app://system/recovery')
+})
+


### PR DESCRIPTION
This is blocked by https://github.com/yodaos-project/yodart/pull/888, and the test result on my local machine is:

```bash
TAP version 13
# should speak text
09-24 15:16:08.156578 D\@ipc-24888(24888): Received VuiDaemon event event:audioFocus:gain
ok 1 should be equal
09-24 15:16:08.174326 V\speech-synthesis(24888): speaking utterance(当前设备没有电池，请拔掉电源进行关机操作)
ok 2 should be equal
# should enter recovery mode
09-24 15:16:13.137036 D\@ipc-24888(24888): Received VuiDaemon event event:audioFocus:gain
09-24 15:16:13.139649 V\src/rk_ffplay.c      4921(24888): prepare async begin
09-24 15:16:13.146318 V\src/rk_ffplay.c      4933(24888): prepare wait async
09-24 15:16:13.195249 V\src/rk_ffplay.c      3467(24888): stream_component_open: SDL_PauseAudioDevices audio_dev = 2
09-24 15:16:13.195555 V\src/rk_ffplay.c      5249(24888): Notify message 1!
09-24 15:16:13.195739 V\src/rk_ffplay.c      5230(24888): Event callback
09-24 15:16:13.196116 V\src/media-player.cc   17(24888):  media_player_event_callback
09-24 15:16:13.196642 V\src/media-player.cc  332(24888): event(1) calling js
09-24 15:16:13.197069 V\src/media-player.cc  339(24888): js for event(1)
09-24 15:16:13.203703 V\src/rk_ffplay.c      4993(24888): rplayer_resume begin
09-24 15:16:13.204183 V\src/rk_ffplay.c      1957(24888): stream_toggle_pause begin  media is paused
09-24 15:16:13.204734 V\src/rk_ffplay.c      1984(24888): stream_toggle_pause is over
09-24 15:16:13.205170 V\src/rk_ffplay.c      4999(24888): rplayer_resume over
09-24 15:16:13.205732 V\src/media-player.cc  343(24888): fired
09-24 15:16:13.208086 V\src/rk_ffplay.c      3956(24888): rk_ffplay av_read_frame ret -541478725
09-24 15:16:13.208323 V\src/rk_ffplay.c      3966(24888): rk_ffplay stream_total_time:3 last_pkt_time:3
09-24 15:16:13.213925 V\src/rk_ffplay.c      5249(24888): Notify message 8!
09-24 15:16:13.214344 V\src/rk_ffplay.c      5230(24888): Event callback
09-24 15:16:13.215231 V\src/media-player.cc   17(24888):  media_player_event_callback
09-24 15:16:13.216071 V\src/media-player.cc  332(24888): event(8) calling js
09-24 15:16:13.216757 V\src/media-player.cc  339(24888): js for event(8)
09-24 15:16:13.218280 V\src/media-player.cc  343(24888): fired
09-24 15:16:16.289109 V\src/rk_ffplay.c      5249(24888): Notify message 2!
09-24 15:16:16.289355 V\src/rk_ffplay.c      5230(24888): Event callback
09-24 15:16:16.289496 V\src/media-player.cc   17(24888):  media_player_event_callback
09-24 15:16:16.289579 V\src/media-player.cc  332(24888): event(2) calling js
09-24 15:16:16.289633 V\src/media-player.cc  339(24888): js for event(2)
09-24 15:16:16.290477 V\src/media-player.cc  343(24888): fired
ok 3 should be truthy
ok 4 should be equal
recovery: play recovery.mp3 before playing shutdown effect
1..4
# tests 4
# pass  4
# ok
```